### PR TITLE
Rescue failed gallery upload

### DIFF
--- a/app/assets/javascripts/bootsy/bootsy.js
+++ b/app/assets/javascripts/bootsy/bootsy.js
@@ -100,6 +100,11 @@ Bootsy.Area.prototype.setUploadForm = function(html) {
   }.bind(this));
 };
 
+// The image upload failed
+Bootsy.Area.prototype.imageUploadFailed = function() {
+  alert(Bootsy.translations[this.locale].error);
+  this.showRefreshButton();
+};
 
 // Set image gallery
 Bootsy.Area.prototype.setImageGallery = function() {
@@ -114,7 +119,9 @@ Bootsy.Area.prototype.setImageGallery = function() {
     },
     dataType: 'json',
     success: function(data) {
+      this.hideRefreshButton();
       this.hideGalleryLoadingAnimation();
+      this.find('.bootsy-gallery .bootsy-image').remove();
 
       $.each(data.images, function(index, value) {
         this.addImage(value);
@@ -128,11 +135,7 @@ Bootsy.Area.prototype.setImageGallery = function() {
 
       this.modal.data('gallery-loaded', true);
     }.bind(this),
-    error: function() {
-      alert(Bootsy.translations[this.locale].error);
-
-      this.showRefreshButton();
-    }.bind(this)
+    error: this.imageUploadFailed.bind(this)
   });
 };
 
@@ -151,7 +154,6 @@ Bootsy.Area.prototype.deleteImage = function (id) {
     }
   }.bind(this));
 };
-
 
 // Add image to gallery
 Bootsy.Area.prototype.addImage = function(html) {
@@ -261,6 +263,8 @@ Bootsy.Area.prototype.init = function() {
       this.modal.on('ajax:success', '.destroy-btn', function(evt, data) {
         this.deleteImage(data.id);
       }.bind(this));
+
+      this.modal.on('ajax:error', '.bootsy-upload-form', this.imageUploadFailed.bind(this));
 
       this.modal.on('ajax:success', '.bootsy-upload-form', function(evt, data) {
         this.setImageGalleryId(data.gallery_id);

--- a/app/assets/javascripts/bootsy/bootsy.js
+++ b/app/assets/javascripts/bootsy/bootsy.js
@@ -101,8 +101,17 @@ Bootsy.Area.prototype.setUploadForm = function(html) {
 };
 
 // The image upload failed
-Bootsy.Area.prototype.imageUploadFailed = function() {
-  alert(Bootsy.translations[this.locale].error);
+Bootsy.Area.prototype.imageUploadFailed = function(e, xhr, status, error) {
+  this.invalidErrors = xhr.responseJSON;
+  if (Number(xhr.status) === 422 && this.invalidErrors.image_file) {
+    this.hideUploadLoadingAnimation();
+    if (this.validation) this.validation.remove();
+    this.validation = $("<p class='text-danger'>");
+    this.validation.text(this.invalidErrors.image_file[0]);
+    this.find('.bootsy-upload-form').append(this.validation);
+  } else {
+    alert(Bootsy.translations[this.locale].error);
+  }
   this.showRefreshButton();
 };
 

--- a/app/controllers/bootsy/application_controller.rb
+++ b/app/controllers/bootsy/application_controller.rb
@@ -1,5 +1,5 @@
 module Bootsy
-  class ApplicationController < ActionController::Base
+  class ApplicationController < Bootsy.base_controller
     # Prevent CSRF attacks by raising an exception.
     # For APIs, you may want to use :null_session instead.
     protect_from_forgery with: :exception

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Bootsy::Engine.routes.draw do
   resources :image_galleries, only: [] do
-    resources :images, only: [:index, :create, :update, :destroy]
+    resources :images, only: [:index, :create, :destroy]
   end
 
-  file_routes = [:index, :create, :update]
+  file_routes = [:index, :create]
 
   file_routes << :destroy if Bootsy.allow_destroy
 

--- a/features/step_definitions/global_steps.rb
+++ b/features/step_definitions/global_steps.rb
@@ -44,3 +44,7 @@ end
 Then(/^I see "(.*?)" on the page$/) do |content|
   expect(page).to have_content(content)
 end
+
+Then(/^I don't see "(.*?)" on the page$/) do |content|
+  expect(page).not_to have_content(content)
+end

--- a/features/upload_image.feature
+++ b/features/upload_image.feature
@@ -16,12 +16,17 @@ Feature: Upload an image
     And I press "Go"
     Then I see the thumbnail "test.jpg" on the image gallery
 
-  Scenario: Upload an invaild image
+  Scenario: Upload an invalid image
     When I attach the file "test.fake" on "image_file"
     Then I don't see the thumbnail "test.jpg" on the image gallery
     Then I see "You are not allowed to upload" on the page
     When I press "Refresh"
     Then I don't see "You are not allowed to upload" on the page
+
+  Scenario: Upload an invalid image from a URL
+    When I fill in "image[remote_image_file_url]" with "http://stubhost.com/test.fake"
+    And I press "Go"
+    Then I see "You are not allowed to upload" on the page
 
   Scenario: Associate the uploaded image with the container
     When I upload the image "test.jpg"

--- a/features/upload_image.feature
+++ b/features/upload_image.feature
@@ -16,6 +16,13 @@ Feature: Upload an image
     And I press "Go"
     Then I see the thumbnail "test.jpg" on the image gallery
 
+  Scenario: Upload an invaild image
+    When I attach the file "test.fake" on "image_file"
+    Then I don't see the thumbnail "test.jpg" on the image gallery
+    Then I see "You are not allowed to upload" on the page
+    When I press "Refresh"
+    Then I don't see "You are not allowed to upload" on the page
+
   Scenario: Associate the uploaded image with the container
     When I upload the image "test.jpg"
     And I insert the image "test.jpg" on the text

--- a/lib/bootsy.rb
+++ b/lib/bootsy.rb
@@ -56,6 +56,10 @@ module Bootsy
   mattr_accessor :store_dir
   @@store_dir = 'uploads'
 
+  # Specify which controller to inherit from
+  mattr_accessor :base_controller
+  @@base_controller = ActionController::Base
+
   # Default way to setup Bootsy. Run rails generate bootsy:install
   # to create a fresh initializer with all configuration values.
   def self.setup

--- a/lib/bootsy/container.rb
+++ b/lib/bootsy/container.rb
@@ -11,43 +11,41 @@ module Bootsy
     extend ActiveSupport::Concern
 
     included do
-      class_eval do
-        has_one :bootsy_image_gallery,
-                class_name: 'Bootsy::ImageGallery',
-                as: :bootsy_resource,
-                dependent: :destroy
+      has_one :bootsy_image_gallery,
+              class_name: 'Bootsy::ImageGallery',
+              as: :bootsy_resource,
+              dependent: :destroy
+    end
 
-        # Public: Get the `id` attribute of the image gallery.
-        #
-        # Returns an Integer id or nil when there is
-        # not an image gallery.
-        def bootsy_image_gallery_id
-          bootsy_image_gallery.try(:id)
-        end
+    # Public: Get the `id` attribute of the image gallery.
+    #
+    # Returns an Integer id or nil when there is
+    # not an image gallery.
+    def bootsy_image_gallery_id
+      bootsy_image_gallery.try(:id)
+    end
 
-        # Public: Set the image gallery `id` and save
-        # the association between models.
-        #
-        # Examples
-        #
-        #   container.id
-        #   # => 34
-        #   gallery.id
-        #   # => 12
-        #   container.bootsy_image_gallery_id = gallery.id
-        #   container.image_gallery_id
-        #   # => 12
-        #   gallery.bootsy_resource.id
-        #   # => 34
-        def bootsy_image_gallery_id=(value)
-          if bootsy_image_gallery.nil? && value.present?
-            self.bootsy_image_gallery = Bootsy::ImageGallery.find(value)
-            bootsy_image_gallery.bootsy_resource = self
-            bootsy_image_gallery.save
-          else
-            value
-          end
-        end
+    # Public: Set the image gallery `id` and save
+    # the association between models.
+    #
+    # Examples
+    #
+    #   container.id
+    #   # => 34
+    #   gallery.id
+    #   # => 12
+    #   container.bootsy_image_gallery_id = gallery.id
+    #   container.image_gallery_id
+    #   # => 12
+    #   gallery.bootsy_resource.id
+    #   # => 34
+    def bootsy_image_gallery_id=(value)
+      if bootsy_image_gallery.nil? && value.present?
+        self.bootsy_image_gallery = Bootsy::ImageGallery.find(value)
+        bootsy_image_gallery.bootsy_resource = self
+        bootsy_image_gallery.save
+      else
+        value
       end
     end
   end

--- a/lib/generators/bootsy/templates/bootsy.rb
+++ b/lib/generators/bootsy/templates/bootsy.rb
@@ -61,4 +61,9 @@ Bootsy.setup do |config|
   # Store directory (inside 'public') for storage = :file
   #   BE CAREFUL! Changing this may break previously uploaded file paths!
   # config.store_dir = 'uploads'
+  #
+  #
+  # Specify the controller to inherit from. Using ApplicationController
+  # allows you to perform authentication from within your app.
+  # config.base_controller = ActionController::Base
 end

--- a/spec/dummy/public/test.fake
+++ b/spec/dummy/public/test.fake
@@ -1,0 +1,1 @@
+This file is used for testing invalid image uploads.


### PR DESCRIPTION
When a file failed to upload to a gallery, the loading icon would just sit there spinning. The error wasn't being caught. The `imageUploadFailed` function was added because the error behavior was used in multiple places. The problem can be replicated by attempting to upload a file with a strange extension.

After handling the errors, the refresh button wasn't being hidden after being clicked. Every time it was clicked, it would refetch the images without clearing the images that were already there.

Also, as far as I know, there's no reason to use class_eval inside the included block when using ActiveSupport::Concern. The included block is for class level macros, like `has_one` or `attr_accessor`. No need to put instance methods in the included block.