### PR TITLE
Allow uploading images from a url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,4 @@ gem 'shoulda-matchers'
 gem 'selenium-webdriver'
 gem 'pry-rails'
 gem 'rubocop'
+gem 'sham_rack', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sham_rack (1.3.6)
+      rack
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     simple_form (3.1.0)
@@ -246,6 +248,7 @@ DEPENDENCIES
   rubocop
   sass-rails
   selenium-webdriver
+  sham_rack
   shoulda-matchers
   simple_form
   sqlite3

--- a/app/assets/stylesheets/bootsy.css
+++ b/app/assets/stylesheets/bootsy.css
@@ -314,6 +314,10 @@ textarea.bootsy:required:invalid {
   padding-right: 5px;
 }
 
+.bootsy-upload-spacer {
+  padding: 0 10px 0 10px;
+}
+
 .bootsy-gallery-loader {
   display: block;
   margin: 0 auto;

--- a/app/controllers/bootsy/images_controller.rb
+++ b/app/controllers/bootsy/images_controller.rb
@@ -2,8 +2,9 @@ require_dependency 'bootsy/application_controller'
 
 module Bootsy
   class ImagesController < Bootsy::ApplicationController
+    before_action :set_gallery, only: [:index, :create]
+
     def index
-      @gallery = find_gallery
       @images = @gallery.images
 
       respond_to do |format|
@@ -19,7 +20,6 @@ module Bootsy
     end
 
     def create
-      @gallery = find_gallery
       @gallery.save!
       @image = @gallery.images.new(image_params)
 
@@ -41,8 +41,8 @@ module Bootsy
 
     private
 
-    def find_gallery
-      ImageGallery.find(params[:image_gallery_id])
+    def set_gallery
+      @gallery = ImageGallery.find(params[:image_gallery_id])
     end
 
     # Private: Returns the String markup to render
@@ -72,7 +72,7 @@ module Bootsy
     end
 
     def image_params
-      params.require(:image).permit(:image_file)
+      params.require(:image).permit(:image_file, :remote_image_file_url)
     end
 
     def create_and_respond

--- a/app/views/bootsy/images/_new.html.erb
+++ b/app/views/bootsy/images/_new.html.erb
@@ -4,5 +4,14 @@
 
   <%= image_tag 'bootsy/upload-loader.gif', class: 'bootsy-upload-loader' %>
 
+  <div class="input-group">
+    <%= f.url_field :remote_image_file_url, class: 'form-control', placeholder: t('bootsy.action.enter_image_url') %>
+    <span class="input-group-btn">
+      <%= f.submit t('bootsy.action.submit_upload'), class: 'btn btn-default' %>
+    </span>
+  </div>
+
+  <span class="bootsy-upload-spacer"><%= t('bootsy.action.or') %></span>
+
   <%= f.file_field :image_file, title: t('bootsy.action.upload') %>
 <% end %>

--- a/config/locales/bootsy.en.yml
+++ b/config/locales/bootsy.en.yml
@@ -5,7 +5,10 @@ en:
       destroy: Delete
       close: Close
       load: Load
+      or: or
       upload: Upload New Image
+      submit_upload: Go
+      enter_image_url: Enter a URL from the web...
     image_gallery: Image Gallery
     image:
       s: Image

--- a/config/locales/bootsy.pt-BR.yml
+++ b/config/locales/bootsy.pt-BR.yml
@@ -5,7 +5,10 @@ pt-BR:
       destroy: Apagar
       close: Fechar
       load: Carregar
+      or: ou
       upload: Nova imagem
+      submit_upload: Ir
+      enter_image_url: Digite uma URL da web...
     image_gallery: Galeria de Imagens
     image:
       s: Imagem

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,6 +19,13 @@ require 'cucumber/rails'
 # If you use factory girl, I had to add the following...
 require 'factory_girl_rails'
 
+# ShamRack is used to mock a remote webserver. It will serve all files in the dummy's
+# public folder. Send requests to stubhost.com/:your_filename.
+require 'sham_rack'
+ShamRack.at('stubhost.com').rackup do
+  run Rack::Directory.new(Rails.root.join('public').to_s)
+end
+
 #Dir[File.expand_path(File.dirname(__FILE__) + "/../../spec/factories/*.rb")].each do |f|
 #  require f
 #end
@@ -78,4 +85,3 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
-

--- a/features/upload_image.feature
+++ b/features/upload_image.feature
@@ -11,6 +11,11 @@ Feature: Upload an image
     When I attach the file "test.jpg" on "image_file"
     Then I see the thumbnail "test.jpg" on the image gallery
 
+  Scenario: Upload a valid image from a URL
+    When I fill in "image[remote_image_file_url]" with "http://stubhost.com/test.jpg"
+    And I press "Go"
+    Then I see the thumbnail "test.jpg" on the image gallery
+
   Scenario: Associate the uploaded image with the container
     When I upload the image "test.jpg"
     And I insert the image "test.jpg" on the text


### PR DESCRIPTION
Carrierwave allows you to upload images from a url by simply surrounding the image parameter name with "remote" and "url". This PR just adds that input as well as a button to submit.

I don't speak Portugese, so I hope Google Translate was correct!