### PR TITLE
Add a polyfill for Function.prototype.bind

### DIFF
--- a/app/assets/javascripts/bootsy.js
+++ b/app/assets/javascripts/bootsy.js
@@ -1,4 +1,5 @@
 //= require jquery.remotipart
+//= require bootsy/polyfill
 //= require bootsy/wysihtml5
 //= require bootsy/bootstrap-wysihtml5
 //= require bootsy/bootsy

--- a/app/assets/javascripts/bootsy/polyfill.js
+++ b/app/assets/javascripts/bootsy/polyfill.js
@@ -1,0 +1,29 @@
+/*
+  Bootsy makes use of Function.prototype.bind, which is not supported by some older browsers.
+  Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+*/
+
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
+
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP && oThis
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}


### PR DESCRIPTION
Function.prototype.bind isn't supported by all browsers. This PR just adds the polyfill mentioned here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind.

Alternatively, you could just not use bind and go with traditional this/that.

I personally use Poltergeist (which doesn't support Function.prototype.bind) as my javascript driver for Capybara and every test fails like this:

```
Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).
       
       TypeError: 'undefined' is not a function (evaluating 'this.modal.find.bind(this.modal)')
       TypeError: 'undefined' is not a function (evaluating 'this.modal.find.bind(this.modal)')
           at http://127.0.0.1:37970/assets/application.js:23283
           at http://127.0.0.1:37970/assets/application.js:23693
           at http://127.0.0.1:37970/assets/application.js:375
           at http://127.0.0.1:37970/assets/application.js:140
           at http://127.0.0.1:37970/assets/application.js:23705
           at http://127.0.0.1:37970/assets/application.js:23710
           at http://127.0.0.1:37970/assets/application.js:3095
           at http://127.0.0.1:37970/assets/application.js:3207
           at http://127.0.0.1:37970/assets/application.js:3413
           at http://127.0.0.1:37970/assets/application.js:3429 in completed
```