### PR TITLE
Image Margins in the Editor

### DIFF
--- a/app/assets/stylesheets/bootsy.css
+++ b/app/assets/stylesheets/bootsy.css
@@ -292,6 +292,10 @@ ul.wysihtml5-toolbar div[data-wysihtml5-command-value="orange"] {
   content: "";
 }
 
+.bootsy img {
+  margin: 8px;
+}
+
 textarea.bootsy:required:invalid {
   color: inherit;
 }


### PR DESCRIPTION
While editing the text you write comes right next to the image without any spacing. That doesn't look good. This might fix that and improve the editing experience.

Here are screenshots for a preview.

Before:
![bootsy image 1](https://cloud.githubusercontent.com/assets/8947356/12702425/13b95bd8-c84f-11e5-9e49-134baab20feb.png)

After:
![bootsy image 2](https://cloud.githubusercontent.com/assets/8947356/12702426/13bbea1a-c84f-11e5-8d99-734f54ffaad8.png)