### PR TITLE
Delete empty upload dirs patch

### DIFF
--- a/app/uploaders/bootsy/image_uploader.rb
+++ b/app/uploaders/bootsy/image_uploader.rb
@@ -35,5 +35,15 @@ module Bootsy
     def extension_white_list
       %w(jpg jpeg gif png)
     end
+
+    after :remove, :delete_empty_upstream_dirs
+
+    def delete_empty_upstream_dirs
+      path = File.expand_path(store_dir, root)
+      Dir.delete(path) # fails if path not empty dir
+
+    rescue SystemCallError
+      true # nothing, the dir is not empty
+    end
   end
 end

--- a/spec/features/foreign_gallery_spec.rb
+++ b/spec/features/foreign_gallery_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spec_helper'
 
 describe 'foreign gallery', type: :feature, js: true do
   it 'is possible' do
@@ -20,6 +21,8 @@ describe 'foreign gallery', type: :feature, js: true do
 
     click_on 'Insert image'
     attach_file 'image[image_file]', Rails.root.to_s + '/public/test.jpg'
+    wait_for_ajax
+
     find('[data-dismiss=modal]').click
     click_on 'Create Comment'
     click_on 'Edit'

--- a/spec/features/image_deletion_spec.rb
+++ b/spec/features/image_deletion_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spec_helper'
 
 describe 'image deletion', type: :feature, js: true do
   let(:selector) do
@@ -10,6 +11,7 @@ describe 'image deletion', type: :feature, js: true do
     visit new_post_path
     click_on 'Insert image'
     attach_file 'image[image_file]', Rails.root.to_s + '/public/test.jpg'
+    wait_for_ajax
   end
 
   it 'can be performed' do

--- a/spec/features/image_gallery_modal_spec.rb
+++ b/spec/features/image_gallery_modal_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
+require 'spec_helper'
 
 describe 'image gallery modal', type: :feature, js: true do
   it 'is accessible with a new resource' do
     visit new_post_path
 
     click_on 'Insert image'
+    wait_for_ajax
 
     expect(page).to have_css('.bootsy-modal', visible: true)
     expect(page).not_to have_css('.bootsy-image', visible: true)

--- a/spec/features/image_insertion_spec.rb
+++ b/spec/features/image_insertion_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spec_helper'
 
 describe 'image insertion', type: :feature, js: true do
   let(:size_positions) do
@@ -23,6 +24,7 @@ describe 'image insertion', type: :feature, js: true do
       visit new_post_path
       click_on 'Insert image'
       attach_file 'image[image_file]', Rails.root.to_s + '/public/test.jpg'
+      wait_for_ajax
 
       find('.bootsy-gallery img').click
       size = size_position.first

--- a/spec/features/image_upload_spec.rb
+++ b/spec/features/image_upload_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sham_rack'
+require 'spec_helper'
 
 describe 'image upload', type: :feature, js: true do
   let(:thumb_selector) do
@@ -18,6 +19,7 @@ describe 'image upload', type: :feature, js: true do
 
   it 'works with local files' do
     attach_file 'image[image_file]', Rails.root.to_s + '/public/test.jpg'
+    wait_for_ajax
 
     expect(page).to have_selector(:xpath, thumb_selector, visible: true)
   end
@@ -25,17 +27,21 @@ describe 'image upload', type: :feature, js: true do
   it 'works with remote files' do
     fill_in 'image[remote_image_file_url]', with: 'http://stubhost.com/test.jpg'
     click_on 'Go'
+    wait_for_ajax
 
     expect(page).to have_selector(:xpath, thumb_selector, visible: true)
   end
 
   it 'handles invalid images' do
     attach_file 'image[image_file]', Rails.root.to_s + '/public/test.fake'
+    wait_for_ajax
 
     expect(page).not_to have_selector(
       :xpath, "//div[contains(@class, 'bootsy-gallery')]//img", visible: true)
     expect(page).to have_content('You are not allowed to upload')
     click_on 'Refresh'
+    wait_for_ajax
+
     expect(page).not_to have_content('You are not allowed to upload')
   end
 
@@ -43,6 +49,7 @@ describe 'image upload', type: :feature, js: true do
     fill_in 'image[remote_image_file_url]',
             with: 'http://stubhost.com/test.fake'
     click_on 'Go'
+    wait_for_ajax
 
     expect(page).not_to have_selector(
       :xpath, "//div[contains(@class, 'bootsy-gallery')]//img", visible: true)
@@ -51,6 +58,8 @@ describe 'image upload', type: :feature, js: true do
 
   it 'associates the uploaded image with the resource' do
     attach_file 'image[image_file]', Rails.root.to_s + '/public/test.jpg'
+    wait_for_ajax
+
     find(:xpath, "//div[contains(@class, 'bootsy-gallery')]//img[contains(@src"\
       ", '/thumb_test.jpg')]").click
     script = "$('.dropdown-submenu .dropdown-menu').hide(); "\

--- a/spec/features/remote_form_spec.rb
+++ b/spec/features/remote_form_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spec_helper'
 
 describe 'remote form', type: :feature, js: true do
   it 'works with Bootsy' do
@@ -7,6 +8,7 @@ describe 'remote form', type: :feature, js: true do
     fill_in 'Title', with: 'Awesome post'
     click_on 'Insert image'
     attach_file 'image[image_file]', Rails.root.to_s + '/public/test.jpg'
+    wait_for_ajax
     find('.bootsy-gallery img[src$="/thumb_test.jpg"]').click
     script = "$('.dropdown-submenu .dropdown-menu').hide(); "\
       "$('a:contains(Small):visible').parent()."\

--- a/spec/features/simple_form_spec.rb
+++ b/spec/features/simple_form_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
+require 'spec_helper'
 
 describe 'simple form', type: :feature, js: true do
   it 'is compatible with Bootsy' do
     visit new_simple_form_post_path
     click_on 'Insert image'
     attach_file 'image[image_file]', Rails.root.to_s + '/public/test.jpg'
+    wait_for_ajax
     selector = "//div[contains(@class, 'bootsy-gallery')]//img[contains(@src, "\
       "'/thumb_test.jpg')]"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,23 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+module WaitForAjax
+  def wait_for_ajax timeout = Capybara.default_max_wait_time * 3
+    Timeout.timeout(timeout) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+
 RSpec.configure do |config|
+
+  config.include WaitForAjax, type: :feature
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -4,31 +4,45 @@ require 'carrierwave/test/matchers'
 describe Bootsy::ImageUploader do
   include CarrierWave::Test::Matchers
 
-  before :all do
-    path_to_file = Rails.root.to_s + '/public/test.jpg'
-    @uploader = Bootsy::ImageUploader.new FactoryGirl.build(:image), :image_file
-    @uploader.store! File.open(path_to_file)
+  describe 'respects dimensions' do
+    before :all do
+      path_to_file = Rails.root.to_s + '/public/test.jpg'
+      @uploader = Bootsy::ImageUploader.new FactoryGirl.build(:image), :image_file
+      @uploader.store! File.open(path_to_file)
+    end
+
+    after(:all) { @uploader.remove! }
+
+    it 'respects dimensions for the original version' do
+      expect(@uploader).to be_no_larger_than(1160, 2000)
+    end
+
+    it 'respects dimensions for the thumb version' do
+      expect(@uploader.thumb).to have_dimensions(60, 60)
+    end
+
+    it 'respects dimensions for the small version' do
+      expect(@uploader.small).to be_no_larger_than(Bootsy.small_image[:width], Bootsy.small_image[:height])
+    end
+
+    it 'respects dimensions for the medium version' do
+      expect(@uploader.medium).to be_no_larger_than(Bootsy.medium_image[:width], Bootsy.medium_image[:height])
+    end
+
+    it 'respects dimensions for the large version' do
+      expect(@uploader.large).to be_no_larger_than(Bootsy.large_image[:width], Bootsy.large_image[:height])
+    end
   end
 
-  after(:all) { @uploader.remove! }
-
-  it 'respects dimensions for the original version' do
-    expect(@uploader).to be_no_larger_than(1160, 2000)
+  describe 'deletes empty dirs' do
+    it 'deletes empty dirs after remove' do
+      path_to_file = Rails.root.to_s + '/public/test.jpg'
+      @uploader = Bootsy::ImageUploader.new FactoryGirl.build(:image), :image_file
+      @uploader.model.id = 99999 # some id to use a separate dir
+      @uploader.store! File.open(path_to_file)
+      expect(File).to exist File.expand_path(@uploader.store_dir, @uploader.root)
+      @uploader.remove!
+      expect(File).not_to exist File.expand_path(@uploader.store_dir, @uploader.root)
+    end
   end
-
-  it 'respects dimensions for the thumb version' do
-    expect(@uploader.thumb).to have_dimensions(60, 60)
-  end
-
-  it 'respects dimensions for the small version' do
-    expect(@uploader.small).to be_no_larger_than(Bootsy.small_image[:width], Bootsy.small_image[:height])
-  end
-
-  it 'respects dimensions for the medium version' do
-    expect(@uploader.medium).to be_no_larger_than(Bootsy.medium_image[:width], Bootsy.medium_image[:height])
-  end
-
-  it 'respects dimensions for the large version' do
-    expect(@uploader.large).to be_no_larger_than(Bootsy.large_image[:width], Bootsy.large_image[:height])
-  end
-end
+ end


### PR DESCRIPTION
There are two commits:
1 - ImageUploader deletes an empty folder after removing files from it.
2 - Little fixes for tests to pass in a slow environment. 

Relevant documentation: https://github.com/carrierwaveuploader/carrierwave/wiki/How-to%3A-Make-a-fast-lookup-able-storage-directory-structure