### PR TITLE
Render images without layout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Bootsy Changelog
 
 ## master
+* Fix bug when image uploader are rendered with main app layout (#211)
 
 * Bootsy no longer depends on Remotipart.
 

--- a/app/controllers/bootsy/images_controller.rb
+++ b/app/controllers/bootsy/images_controller.rb
@@ -54,7 +54,8 @@ module Bootsy
       render_to_string(
         file: 'bootsy/images/_image',
         formats: [:html],
-        locals: { image: image }
+        locals: { image: image },
+        layout: false
       )
     end
 
@@ -67,7 +68,8 @@ module Bootsy
       render_to_string(
         file: 'bootsy/images/_new',
         formats: [:html],
-        locals: { gallery: gallery, image: gallery.images.new }
+        locals: { gallery: gallery, image: gallery.images.new },
+        layout: false
       )
     end
 


### PR DESCRIPTION
When config.base_controller = ApplicationController, images in modal form are rendered with main app layout.

Fixes #211