### PR TITLE
Bootsy has no inherent dependency on Rails, conditionally require it

### DIFF
--- a/lib/bootsy.rb
+++ b/lib/bootsy.rb
@@ -1,5 +1,5 @@
 require 'carrierwave'
-require 'bootsy/engine'
+require 'bootsy/engine' if defined?(Rails)
 require 'bootsy/container'
 require 'bootsy/form_helper'
 require 'bootsy/form_builder'


### PR DESCRIPTION
Bootsy is predominantly a Rails extension (views etc.). However, the data model components (ActiveModel & CarrierWave) of Bootsy are not specifically tied to Rails and can be used without it.

A client of mine, for which I just integrated Bootsy, has their data model in a Gem, shared across various projects; only one of which is Rails, the rest are Sinatra etc. (ActiveModel & CarrierWave, but nothing else Rails).

Consequently, this pull request conditionally requires the Bootsy Rails Engine.