### PR TITLE
Pass through change event to the textarea

### DIFF
--- a/app/assets/javascripts/bootsy/area.js
+++ b/app/assets/javascripts/bootsy/area.js
@@ -24,6 +24,7 @@ Bootsy.Area = function($el) {
     events: {
       change: function() {
         self.unsavedChanges = true;
+        $el.trigger('change');
       }
     }
   };


### PR DESCRIPTION
Presently the DOM `change` event is not triggered on the `textarea` by wysihtml5. It's sometimes required to know when the content has changed.

My use case is that I have a form made up of many fields. These fields are aggregated into another field on the same page - so I need to know when fields change, so as to update the aggregated field accordingly.