### PR TITLE
Rails.application.config.active_record.belongs_to_required_by_default…

### DIFF
--- a/lib/bootsy/activerecord/image_gallery.rb
+++ b/lib/bootsy/activerecord/image_gallery.rb
@@ -10,7 +10,8 @@ module Bootsy
   # that do not point to resources older than the given time
   # limit.
   class ImageGallery < ActiveRecord::Base
-    belongs_to :bootsy_resource, polymorphic: true, autosave: false
+    belongs_to :bootsy_resource, polymorphic: true, autosave: false,
+                                 optional: true
     has_many :images, dependent: :destroy
 
     scope :destroy_orphans, lambda { |time_limit|

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,3 +1,3 @@
 class Comment < ActiveRecord::Base
-  belongs_to :post
+  belongs_to :post, optional: true
 end

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -1,0 +1,24 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.0 upgrade.
+#
+# Read the Rails 5.0 release notes for more info on each option.
+
+# Enable per-form CSRF tokens. Previous versions had false.
+Rails.application.config.action_controller.per_form_csrf_tokens = true
+
+# Enable origin-checking CSRF mitigation. Previous versions had false.
+Rails.application.config.action_controller.forgery_protection_origin_check = true
+
+# Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
+# Previous versions had false.
+ActiveSupport.to_time_preserves_timezone = true
+
+# Require `belongs_to` associations by default. Previous versions had false.
+Rails.application.config.active_record.belongs_to_required_by_default = true
+
+# Do not halt callback chains when a callback returns false. Previous versions had true.
+ActiveSupport.halt_callback_chains_on_return_false = false
+
+# Configure SSL options to enable HSTS with subdomains. Previous versions had false.
+Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
… is set to `true` for new Rails 5 app as mentioned in https://github.com/volmer/bootsy/issues/243.

http://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html