### PR TITLE
Backwards compatibility with Rails 4 + Fixes modal being swallowed by container

### DIFF
--- a/app/assets/javascripts/bootsy/modal.js
+++ b/app/assets/javascripts/bootsy/modal.js
@@ -99,6 +99,7 @@ Bootsy.Modal = function(area) {
 
 // Show modal
 Bootsy.Modal.prototype.show = function() {
+  this.$el.appendTo('body');
   this.$el.modal('show');
 };
 

--- a/lib/bootsy/activerecord/image_gallery.rb
+++ b/lib/bootsy/activerecord/image_gallery.rb
@@ -10,8 +10,13 @@ module Bootsy
   # that do not point to resources older than the given time
   # limit.
   class ImageGallery < ActiveRecord::Base
-    belongs_to :bootsy_resource, polymorphic: true, autosave: false,
-                                 optional: true
+    if Rails::VERSION::STRING.split(".").first.to_i >= 5
+      belongs_to :bootsy_resource, polymorphic: true, autosave: false,
+                                   optional: true
+    else
+      belongs_to :bootsy_resource, polymorphic: true, autosave: false
+    end
+    
     has_many :images, dependent: :destroy
 
     scope :destroy_orphans, lambda { |time_limit|

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,3 +1,7 @@
 class Comment < ActiveRecord::Base
-  belongs_to :post, optional: true
+  if Rails::VERSION::STRING.split(".").first.to_i >= 5
+    belongs_to :post, optional: true
+  else
+    belongs_to :post
+  end
 end


### PR DESCRIPTION
This includes:

1. Fixes backwards compatibility with Rails 4 by setting the optional flag only if the version >= 5
2. Prior to showing, appends modals to the `body`. I noticed modals would get swallowed if they were in a container that had overflow hidden or used CSS clip-path.