### PR TITLE
jQuery 3.0 support

### DIFF
--- a/app/assets/javascripts/bootsy/init.js
+++ b/app/assets/javascripts/bootsy/init.js
@@ -27,7 +27,7 @@ Bootsy.init = function() {
 
 /* Initialize Bootsy on document load */
 $(function() {
-  $(window).load(function() {
+  $(window).on('load', function() {
     Bootsy.init();
 
     /* Reload Bootsy on page load when using Turbolinks. */


### PR DESCRIPTION
jQuery 3.0 has removed ```load``` event alias.

More info: #258 