### PR TITLE
Restore support for Rails 4

### DIFF
--- a/lib/bootsy/activerecord/image_gallery.rb
+++ b/lib/bootsy/activerecord/image_gallery.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
+# Bootsy Module
 module Bootsy
+  # Options for bootsy_resource for Rails 4 backwards compatibility
+  def self.bootsy_resource_options
+    { polymorphic: true, autosave: false }.tap do |options|
+      options[:optional] = true if Rails::VERSION::MAJOR >= 5
+    end
+  end
+
   # Public: A model that groups all images related to a
   # Bootsy container (also called a resource).
   #
@@ -11,15 +19,14 @@ module Bootsy
   # that do not point to resources older than the given time
   # limit.
   class ImageGallery < ActiveRecord::Base
-    belongs_to :bootsy_resource, polymorphic: true, autosave: false,
-                                 optional: true
+    belongs_to :bootsy_resource, Bootsy.bootsy_resource_options
     has_many :images, dependent: :destroy
 
-    scope :destroy_orphans, lambda { |time_limit|
+    def self.destroy_orphans(time_limit)
       where(
         'created_at < ? AND bootsy_resource_id IS NULL',
         time_limit
       ).destroy_all
-    }
+    end
   end
 end


### PR DESCRIPTION
This commit restores support for Rails 4 by only including the `optional: true` value of the `belongs_to : bootsy_resource` association when Rails 5+ is being used.

Please note I couldn't find any references for this type of situation so while my approach works there may be a better way to get it done. Thanks! 😄 